### PR TITLE
Update xenium-flash.cpp

### DIFF
--- a/xenium-flash/src/xenium-flash.cpp
+++ b/xenium-flash/src/xenium-flash.cpp
@@ -171,6 +171,7 @@ int main(int argc, char** argv)
     {
         //write byte to flash
         flash.Write(i, flash_buffer[i]);
+        while(flash.Read(0) != flash.Read(0));
         
         float current_progress = (float) i / flash_size * 100.0f;
         if (current_progress > progress + 1)


### PR DESCRIPTION
To mimic the same check in xenium-tools to verify the flash is ready for the next write, otherwise it will be ignored and could fail verify. This is in reference to issue #15 