### PR TITLE
Add check to verify next block ready to write with error reporting

### DIFF
--- a/xenium-flash/src/xenium-flash.cpp
+++ b/xenium-flash/src/xenium-flash.cpp
@@ -172,6 +172,23 @@ int main(int argc, char** argv)
         //write byte to flash
         flash.Write(i, flash_buffer[i]);
         
+        //check that write has completed before allowing next chunk to be written
+	    //timeout is 5 seconds per block that is written
+	    uint32_t write_waits = 0;
+	    while (flash.Read(0x00) != flash.Read(0x00))
+        {
+            if (write_waits > 500)
+            {
+                std::cout << std::endl << "ERROR\n\n** XENIUM FLASH WRITE BLOCK TIMEOUT!! **\n" << std::endl;
+                flash.ChipReset();
+                return -1;
+            }
+            else
+            {
+                std::this_thread::sleep_for (std::chrono::milliseconds(10));
+                write_waits++;
+            }
+        }
         float current_progress = (float) i / flash_size * 100.0f;
         if (current_progress > progress + 1)
         {

--- a/xenium-flash/src/xenium-flash.cpp
+++ b/xenium-flash/src/xenium-flash.cpp
@@ -114,6 +114,10 @@ int main(int argc, char** argv)
                   << (int) manufacturer << ", Device:" << (int) deviceid << " **\n" << std::endl;
         return -1;
     }
+    else if ((manufacturer == 0xC2 && deviceid == 0x49) || (manufacturer == 0xC2 && deviceid == 0xC4))
+    {
+        std::cout << "OK [MX29LV160DB]" << std::endl; 
+    }
     else
     {
         std::cout << "OK [Spansion S29AL016J]" << std::endl; 

--- a/xenium-flash/src/xenium-flash.cpp
+++ b/xenium-flash/src/xenium-flash.cpp
@@ -173,9 +173,9 @@ int main(int argc, char** argv)
         flash.Write(i, flash_buffer[i]);
         
         //check that write has completed before allowing next chunk to be written
-	    //timeout is 5 seconds per block that is written
-	    uint32_t write_waits = 0;
-	    while (flash.Read(0x00) != flash.Read(0x00))
+	//timeout is 5 seconds per block that is written
+	uint32_t write_waits = 0;
+	while (flash.Read(0x00) != flash.Read(0x00))
         {
             if (write_waits > 500)
             {
@@ -189,6 +189,7 @@ int main(int argc, char** argv)
                 write_waits++;
             }
         }
+	    
         float current_progress = (float) i / flash_size * 100.0f;
         if (current_progress > progress + 1)
         {

--- a/xenium-flash/src/xenium-flash.cpp
+++ b/xenium-flash/src/xenium-flash.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
     }
     else if ((manufacturer == 0xC2 && deviceid == 0x49) || (manufacturer == 0xC2 && deviceid == 0xC4))
     {
-        std::cout << "OK [MX29LV160DB]" << std::endl; 
+        std::cout << "OK [Macronix MX29LV160DB]" << std::endl; 
     }
     else
     {

--- a/xenium-flash/src/xenium-flash.cpp
+++ b/xenium-flash/src/xenium-flash.cpp
@@ -108,15 +108,15 @@ int main(int argc, char** argv)
                   << "the \"xeniumflash.jed\" file first! **" << std::endl;
         return -1;
     }
+    else if ((manufacturer == 0xC2 && deviceid == 0x49) || (manufacturer == 0xC2 && deviceid == 0xC4))
+    {
+        std::cout << "OK [Macronix MX29LV160DB]" << std::endl; 
+    }
     else if (manufacturer != 0x01 || deviceid != 0xC4)
     {
         std::cout << "ERROR\n\n** XENIUM FLASH DEVICE NOT FOUND - Manufacturer:" 
                   << (int) manufacturer << ", Device:" << (int) deviceid << " **\n" << std::endl;
         return -1;
-    }
-    else if ((manufacturer == 0xC2 && deviceid == 0x49) || (manufacturer == 0xC2 && deviceid == 0xC4))
-    {
-        std::cout << "OK [Macronix MX29LV160DB]" << std::endl; 
     }
     else
     {


### PR DESCRIPTION
Added a check during the write phase to verify the flash is ready before moving to next block. The fixes issues programming original AMD AM29LV160MT-100EI and some troublesome Spansion S29AL016J70TFI010 flash devices that fail the verify check.